### PR TITLE
secure passwords

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -1,17 +1,41 @@
 #!/bin/bash
 
-set -ex
+set -e
+
+if [ -z "$KEYRING_PASSPHRASE" ]; then
+    echo "KEYRING_PASSPHRASE cannot be empty"
+    exit 1
+fi
+
+gpg_present_phrase () {
+    /usr/lib/gnupg2/gpg-preset-passphrase -P "$KEYRING_PASSPHRASE" \
+      -c "$(basename "$GNUPGHOME"/private-keys-v1.d/*.key .key)"
+}
 
 # Go to current user's homedir
 echo "Running as user '$(whoami)' (UID '$UID') in '$PWD'"
 mkdir -p $XDG_CONFIG_HOME $XDG_DATA_HOME $GNUPGHOME $PASSWORD_STORE_DIR
 
+# Start gpg-agent to force allow presetting passphrase
+gpg-agent --homedir "$GNUPGHOME" --daemon --allow-preset-passphrase
+
 # Initialize
 if [[ $1 == init ]]; then
 
-    # Initialize pass
-    gpg --generate-key --batch /protonmail/gpgparams
-    pass init pass-key
+    # Initialize GPG if no private key
+    # While -f can't handle globs, only one key can be generated
+    # shellcheck disable=SC2144
+    if [ ! -f "$GNUPGHOME"/private-keys-v1.d/*.key ]; then
+      gpg --generate-key --passphrase "$KEYRING_PASSPHRASE" --pinentry-mode loopback \
+        --batch /protonmail/gpgparams
+    fi
+
+    # Initialize pass if no password-store
+    if [ ! -f "$PASSWORD_STORE_DIR"/.gpg-id ]; then
+      pass init pass-key
+    fi
+
+    gpg_present_phrase
     
     # Kill the other instance as only one can be running at a time.
     # This allows users to run entrypoint init inside a running conainter
@@ -20,9 +44,11 @@ if [[ $1 == init ]]; then
     pkill -9 bridge || true
 
     # Login
-    /protonmail/proton-bridge --cli $@
+    /protonmail/proton-bridge --cli "$@"
 
 else
+    # Load passphrase into gpg-agent
+    gpg_present_phrase
 
     # socat will make the conn appear to come from 127.0.0.1
     # ProtonMail Bridge currently expects that.
@@ -31,9 +57,6 @@ else
     socat TCP6-LISTEN:1243,fork TCP:127.0.0.1:1143 &
 
     # Start protonmail
-    # Fake a terminal, so it does not quit because of EOF...
-    rm -f faketty
-    mkfifo faketty
-    cat faketty | /protonmail/proton-bridge --cli $@
+    /protonmail/proton-bridge --noninteractive --log-level info
 
 fi

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -17,7 +17,7 @@ if [[ $1 == init ]]; then
     # This allows users to run entrypoint init inside a running conainter
     # which is useful in a k8s environment.
     # || true to make sure this would not fail in case there is no running instance.
-    pkill protonmail-bridge || true
+    pkill -9 bridge || true
 
     # Login
     /protonmail/proton-bridge --cli $@

--- a/build/gpgparams
+++ b/build/gpgparams
@@ -1,7 +1,6 @@
-%no-protection
 %echo Generating a basic OpenPGP key
 Key-Type: RSA
-Key-Length: 2048
+Key-Length: 4096
 Name-Real: pass-key
 Expire-Date: 0
 %commit


### PR DESCRIPTION
The gpg key used by pass is generated with the `no-protection` flag making it insecure and basically plain text. This secures things a bit by:

- removing no-protection flag enabling gpg passphrase protection
- using a docker environment variable as the gpg passphrase
- use `gpg-preset-passphrase` to inject the key into `gpg-agent` preventing password prompts
- remove `set -x` to prevent logging the gpg passphrase
- add checks to prevent re-initing pass and gpg. [^1]
- use noninteractive to prevent printing protonmail-bridge creds to logs

If `set -x` is actually wanted I could try to modify things to use a file instead of an env variables but I'm not sure how nicely things would play with `gpg-preset-passphrase`.

[^1]: This prevents generating extra unused keys and secret stores. This also keeps the script from breaking